### PR TITLE
feat(eln): save and load pref in roc and idb

### DIFF
--- a/eln/preference.js
+++ b/eln/preference.js
@@ -23,7 +23,7 @@ export async function preferencesFactory(id, options) {
     var existing = (await roc.view('entryByKindAndId', {key: [kind, id]}))[0];
     var preferenceRoc;
     var rocOptions = {
-        varName: id,
+        varName: name,
         track: true
     };
     if (existing) {
@@ -36,9 +36,6 @@ export async function preferencesFactory(id, options) {
         });
         preferenceRoc = await roc.document(created._id, rocOptions);
     }
-
-    var preferenceVar = API.getVar(id);
-    API.setVariable(name, preferenceVar, ['$content']);
 
     var viewPreferences = new Preference(roc, preferenceRoc);
 

--- a/eln/preference.js
+++ b/eln/preference.js
@@ -1,0 +1,87 @@
+import API from 'src/util/api';
+import Roc from '../rest-on-couch/Roc';
+import IDB from 'src/util/IDBKeyValue';
+
+export async function preferenceFactory(id, options) {
+    const {
+        kind = 'viewOptions',
+        url = undefined,
+        database = 'eln',
+        initial = []
+    } = options;
+
+    var roc = new Roc({
+        url: url,
+        database: database,
+        kind: kind
+    });
+
+    var idb = new IDB(kind);
+
+    var existing = await roc.view('entryByKindAndId', {key: [kind, id]});
+    var preferenceRoc = existing[0];
+    var newVariable = !preferenceRoc;
+    var local;
+    try {
+        local = await idb.get(id);
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        idb = false;
+    }
+
+    if (local) {
+        preferenceRoc = local;
+    } else if (newVariable) {
+        preferenceRoc = {
+            $id: id,
+            $content: initial,
+            $kind: kind
+        };
+    }
+
+    preferenceRoc = await API.createData(id, preferenceRoc);
+    var preferenceVar = API.getVar(id);
+    API.setVariable('preferences', preferenceVar, ['$content']);
+
+    return new Preference(id, roc, idb, preferenceRoc, newVariable);
+}
+
+export class Preference {
+    constructor(id, roc, idb, preferenceRoc, newVariable) {
+        this.id = id;
+        this.roc = roc;
+        this.idb = idb;
+        this.preference = preferenceRoc;
+        this.newVariable = newVariable;
+        this.contentString = JSON.stringify(this.preference);
+
+        this.onChange = () => {
+            const contentString = JSON.stringify(this.preference);
+            if (contentString !== this.contentString) {
+                this.contentString = contentString;
+                this.idb.set(this.id, JSON.parse(contentString));
+            }
+        };
+
+        this.bindChange();
+    }
+
+    bindChange() {
+        this.preference.unbindChange(this.onChange);
+        this.preference.onChange(this.onChange);
+    }
+
+    unbindChange() {
+        this.preference.unbindChange(this.onChange);
+    }
+
+    async save() {
+        if (this.newVariable) {
+            await this.roc.update(this.preference);
+        } else {
+            this.newVariable = false;
+            this.preference = await this.roc.create(this.preference);
+        }
+    }
+}


### PR DESCRIPTION
## Example
#### Init script
```js
var Sample = await API.require('vh/eln/Sample');
var {preferenceFactory} = await API.require('vh/eln/preference');
if (typeof IframeBridge !== 'undefined') {
    IframeBridge.onMessage(onMessage);
    IframeBridge.ready();
    function onMessage(data) {
        if (data.type === 'tab.data') {
            var options = {
                url: data.message.couchDB.url,
                database: data.message.couchDB.database,
                kind: 'viewOptions'
            };
            var sample = new Sample(data.message.couchDB, data.message.uuid, {track: false});
            preferenceFactory('gcIntegration', options).then((preference) => {
                API.cache('preference', preference);
            });
        }
    }
} else {
    var CDB = await API.require('src/util/couchdbAttachments');
    var c = new CDB();
    var files = await c.fetchList();
    files = files.filter((a) => !a.filename.match(/json$/i));
    var chromatogram = [];
    if (files[0]) {
        chromatogram = chromatogram.concat(files);
    }
    API.createData('chromatogram', chromatogram);
    preferenceFactory('gcIntegration').then((preference) => {
        API.cache('preference', preference);
    });
}
```
#### Code executor
```js
switch(this.action.name) {
    case 'addPreference':
        var preferences = API.getData('preferences');
        var name = await UI.enterValue({
            description: '',
            label: '<h2>Enter the name of the preference</h2>',
            value: ''
        });
        preferences.push({
            name: name  || 'preference' + preferences.length,
            zones:[]
        });
        preferences.triggerChange();
        break;
    case 'savePreference':
        var preference = API.cache('preference');
        preference.save()
        break;
```
